### PR TITLE
Add ClickTrail to Attribution tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The tools listed here are not necessarily mobile analytics tools only. However t
 
 * [Adjust](http://adjust.com/) - open-source SDK with sophisticated analysis and campaign tracking. `©` `SaaS`
 * [Clickmeter](https://clickmeter.com) - analytics tool that helps you track marketing campaigns. `©` `SaaS`
+* [ClickTrail](https://www.npmjs.com/package/@vizuh/clicktrail) - Deterministic first-party attribution engine for UTMs, ad click IDs, referrers, and first/last touch. ([Source Code](https://github.com/vizuh/clicktrail-js)) `MIT` `TypeScript`
 * [HasOffers Mobile app tracking](http://www.mobileapptracking.com/) - attribution analytics platform. `©` `SaaS`
 
 ## Social media analytics


### PR DESCRIPTION
## Summary

- Add ClickTrail to `Attribution tracking`.
- Link the published npm package and MIT-licensed TypeScript source.

## Why this section

ClickTrail parses and carries observed acquisition context: UTMs, ad click IDs, referrers, and first/last touch. It can emit to host-configured `dataLayer` or HTTP destinations, but it is not a general analytics-provider layer, so this keeps one entry under the narrower category.

Disclosure: I maintain ClickTrail through Vizuh OÜ.
