### PR TITLE
Add LLM Pulse to SEO analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 
 ## SEO
 * [Serposcope](https://serposcope.serphacker.com/) - Serposcope is a free and open-source rank tracker to monitor websites ranking in Google and improve your SEO performances. ([Source Code](https://github.com/serphacker/serposcope)) `MIT` `Java`
+* [LLM Pulse](https://llmpulse.ai/) - AI search analytics for tracking brand mentions, citations, sentiment, and competitor share of voice across ChatGPT, Perplexity, Gemini, Google AI Overviews, and Google AI Mode. `©` `SaaS`
 
 ## Privacy focused analytics
 


### PR DESCRIPTION
## Summary

Adds LLM Pulse to the SEO analytics section. It measures brand mentions, citations, sentiment, and competitor share of voice across ChatGPT, Perplexity, Gemini, Google AI Overviews, and Google AI Mode.

- Primary source: https://llmpulse.ai/
- One factual entry using the canonical URL and the existing SaaS tags.
- The link resolves directly, and no existing entry, issue, or pull request was found.

Disclosure: I am a co-founder of LLM Pulse.