### PR TITLE
Add SiteData to SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 ## SEO
 * [Serposcope](https://serposcope.serphacker.com/) - Serposcope is a free and open-source rank tracker to monitor websites ranking in Google and improve your SEO performances. ([Source Code](https://github.com/serphacker/serposcope)) `MIT` `Java`
 
+* [SiteData](https://sitedata.dev/) - website traffic estimation, reverse AdSense lookup, Google Ads advertiser analysis, and Domain Rating lookup. `©` `SaaS`
+
 ## Privacy focused analytics
 
 * [Fathom](https://usefathom.com/) - Fathom Analytics provides simple, useful websites stats without tracking or storing personal data of your users `©` `SaaS`


### PR DESCRIPTION
Adds [SiteData](https://sitedata.dev/) — a website traffic / SEO / Google Ads intelligence tool:

- Website traffic estimation and audience signals
- Reverse AdSense lookup (discover sites connected by the same AdSense Publisher ID)
- Google Ads advertiser & keyword lookup
- Domain lookup and Domain Rating (DR)
- Free tier + browser extension (Chrome / Edge)

Happy to adjust the wording or category if something fits better. Thanks for maintaining this list!
